### PR TITLE
Herokuデプロイエラー解消&MOD Watcher画面作成&初期フォーム作成

### DIFF
--- a/components/appWatcher/ClearRegisteredAppId.vue
+++ b/components/appWatcher/ClearRegisteredAppId.vue
@@ -29,7 +29,7 @@ import Component from 'nuxt-class-component'
 
 import ModalTemplate from '@/components/common/template/ModalTemplate.vue'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 /**
  * 登録中のアプリIDを削除。
@@ -45,7 +45,7 @@ export default class ClearRegisteredAppId extends Vue {
    */
   private clearAppId() {
     // LocalStorageから情報をClear。
-    dataModule.clearAppIdList()
+    appIdDataModule.clearAppIdList()
   }
 }
 </script>

--- a/components/appWatcher/NowPlayerNum.vue
+++ b/components/appWatcher/NowPlayerNum.vue
@@ -21,7 +21,7 @@
 import { Component, Vue, Watch } from 'nuxt-property-decorator'
 import ApiWrapper from '@/components/common/api/ApiWrapper.vue'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 import { appWatcherModule } from '@/store/modules/appWatcherModule'
 
 /**
@@ -40,7 +40,7 @@ export default class NowPlayerNum extends Vue {
 
   async fetch() {
     this.data = await appWatcherModule.getNumberOfCurrentPlayers(
-      dataModule.currentAppId.appId
+      appIdDataModule.currentAppId.appId
     )
   }
 }

--- a/components/appWatcher/achivement/AchivementSummary.vue
+++ b/components/appWatcher/achivement/AchivementSummary.vue
@@ -27,7 +27,7 @@ import ApiWrapper from '@/components/common/api/ApiWrapper.vue'
 import AchivementList from '@/components/appWatcher/achivement/AchivementList.vue'
 
 import { appWatcherModule } from '@/store/modules/appWatcherModule'
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 import MathUtil from '@/utils/mathUtil'
 
 /**
@@ -51,12 +51,12 @@ export default class AchivementSummary extends Vue {
   private steamDbUrl = ''
 
   mounted() {
-    this.steamDbUrl = `https://steamdb.info/app/${dataModule.currentAppId.appId}/stats/`
+    this.steamDbUrl = `https://steamdb.info/app/${appIdDataModule.currentAppId.appId}/stats/`
   }
 
   async fetch() {
     const response = await appWatcherModule.getGlobalAchievementPercentagesForApp(
-      dataModule.currentAppId.appId
+      appIdDataModule.currentAppId.appId
     )
 
     // データが存在=実績データが存在するゲームであすれば格納

--- a/components/common/ReloadSteamApiData.vue
+++ b/components/common/ReloadSteamApiData.vue
@@ -8,7 +8,7 @@
 import Vue from 'vue'
 import Component from 'nuxt-class-component'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 import { IAppId } from '~/store/modules/dataModule/types'
 
 /**
@@ -20,16 +20,16 @@ import { IAppId } from '~/store/modules/dataModule/types'
 export default class ReloadSteamApiData extends Vue {
   private onClickHandler() {
     // 現在選択中のアプリIDを一度空にしてもう一度入れ直すことで、情報を更新
-    const tmp = dataModule.currentAppId
+    const tmp = appIdDataModule.currentAppId
     const emptyData: IAppId = {
       appId: '',
       label: '',
     }
 
     // 短時間でもアプリID画からの状態を作り出し、メインコンポーネントの;key="currentId"を変更検知させる
-    dataModule.setCurrentAppId(emptyData)
+    appIdDataModule.setCurrentAppId(emptyData)
     window.setTimeout(() => {
-      dataModule.setCurrentAppId(tmp)
+      appIdDataModule.setCurrentAppId(tmp)
     }, 100)
   }
 }

--- a/components/common/data/appId/CurrentAppIdList.vue
+++ b/components/common/data/appId/CurrentAppIdList.vue
@@ -17,7 +17,7 @@
 import Vue from 'vue'
 import Component from 'nuxt-class-component'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 import { IAppId } from '~/store/modules/dataModule/types'
 
 /**
@@ -31,18 +31,18 @@ export default class CurrentAppIdList extends Vue {
    * アプリIDのリスト。
    */
   private get appIdList() {
-    return dataModule.appIdList
+    return appIdDataModule.appIdList
   }
 
   /**
    * 現在選択中のアプリID。
    */
   private get currentAppId() {
-    return dataModule.currentAppId
+    return appIdDataModule.currentAppId
   }
 
   private setCurrentAppId(item: IAppId) {
-    dataModule.setCurrentAppId(item)
+    appIdDataModule.setCurrentAppId(item)
   }
 }
 </script>

--- a/components/common/data/appId/ExportAppIdList.vue
+++ b/components/common/data/appId/ExportAppIdList.vue
@@ -27,7 +27,7 @@ import Component from 'nuxt-class-component'
 import ModalTemplate from '@/components/common/template/ModalTemplate.vue'
 import CopyClipBoardButton from '@/components/common/CopyClipBoardButton.vue'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 /**
  * 登録中のアプリIDをエクスポート。。
@@ -42,6 +42,6 @@ export default class ExportAppIdList extends Vue {
   /**
    * アプリIDのリスト。
    */
-  private appIdList = dataModule.appIdList
+  private appIdList = appIdDataModule.appIdList
 }
 </script>

--- a/components/common/data/appId/ImportAppIdList.vue
+++ b/components/common/data/appId/ImportAppIdList.vue
@@ -61,7 +61,7 @@ import { ValidationProvider } from 'vee-validate'
 
 import ModalTemplate from '@/components/common/template/ModalTemplate.vue'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 /**
  * アプリID情報をエクスポート。
@@ -91,7 +91,7 @@ export default class ImportAppIdList extends Vue {
       return
     }
 
-    dataModule.setAppIdList(JSON.parse(this.importAppIdList))
+    appIdDataModule.setAppIdList(JSON.parse(this.importAppIdList))
   }
 }
 </script>

--- a/components/common/data/appId/InitialRegisteredAppId.vue
+++ b/components/common/data/appId/InitialRegisteredAppId.vue
@@ -6,9 +6,9 @@
           <v-text-field
             v-model="appUrl"
             :rules="appUrlRules"
-            label="appUrl"
+            label="アプリURL"
             clearable
-            hint="お気に入りのSteamアプリのURLを入力してください"
+            hint="お気に入りSteamアプリのURLを入力してください"
             persistent-hint
             required
           />
@@ -28,9 +28,9 @@
 import Vue from 'vue'
 import Component from 'nuxt-class-component'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
-import ImportAppIdList from '@/components/common/data/ImportAppIdList.vue'
+import ImportAppIdList from '@/components/common/data/appId/ImportAppIdList.vue'
 
 import { IAppId } from '~/store/modules/dataModule/types'
 import Settings from '~/config/settings'
@@ -59,7 +59,7 @@ export default class InitialRegisteredAppId extends Vue {
    */
   private appUrlRules = [
     (v: string | undefined | null) =>
-      !!v || 'お気に入りのSteamアプリのURLを入力してください',
+      !!v || 'お気に入りSteamアプリのURLを入力してください',
     (v: string) =>
       RegexpUtil.steamUrlToAppId.test(v) ||
       'SteamアプリのURLを入力してください',
@@ -74,10 +74,10 @@ export default class InitialRegisteredAppId extends Vue {
       appId: RegexpUtil.match(this.appUrl, RegexpUtil.steamUrlToAppId),
       label: Settings.appIdInitializeLabel,
     }
-    dataModule.setAppId(data)
+    appIdDataModule.setAppId(data)
 
     // 現在選択中のアプリIDにもデータを登録
-    dataModule.setCurrentAppId(data)
+    appIdDataModule.setCurrentAppId(data)
   }
 }
 </script>

--- a/components/common/data/appId/editAppIdList/AddAppIdList.vue
+++ b/components/common/data/appId/editAppIdList/AddAppIdList.vue
@@ -22,7 +22,7 @@
             :rules="appUrlRules"
             label="appUrl"
             clearable
-            hint="お気に入りのSteamアプリのURLを入力してください"
+            hint="お気に入りSteamアプリのURLを入力してください"
             persistent-hint
             required
           />
@@ -43,7 +43,7 @@
 import Vue from 'vue'
 import Component from 'nuxt-class-component'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 import { IAppId } from '~/store/modules/dataModule/types'
 
@@ -73,7 +73,7 @@ export default class AddAppIdList extends Vue {
    */
   private appUrlRules = [
     (v: string | undefined | null) =>
-      !!v || 'お気に入りのSteamアプリのURLを入力してください',
+      !!v || 'お気に入りSteamアプリのURLを入力してください',
     (v: string) =>
       RegexpUtil.steamUrlToAppId.test(v) ||
       'SteamアプリのURLを入力してください',
@@ -95,7 +95,7 @@ export default class AddAppIdList extends Vue {
       appId: RegexpUtil.match(this.appUrl, RegexpUtil.steamUrlToAppId),
       label: this.label,
     }
-    dataModule.setAppId(data)
+    appIdDataModule.setAppId(data)
 
     // フォーム内容をClean
     this.clearForm()

--- a/components/common/data/appId/editAppIdList/AppIdList.vue
+++ b/components/common/data/appId/editAppIdList/AppIdList.vue
@@ -36,7 +36,7 @@
 import Vue from 'vue'
 import Component from 'nuxt-class-component'
 
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 import { IAppId } from '~/store/modules/dataModule/types'
 
@@ -50,7 +50,7 @@ export default class AppIdList extends Vue {
   /**
    * アプリIDのリスト。
    */
-  private appIdList = dataModule.appIdList
+  private appIdList = appIdDataModule.appIdList
 
   /**
    * DataTableのヘッダー。
@@ -93,7 +93,7 @@ export default class AppIdList extends Vue {
    */
   private onClickSaveHandler() {
     // アプリIDデータをセット。
-    dataModule.setAppIdList(this.appIdList)
+    appIdDataModule.setAppIdList(this.appIdList)
   }
 
   /**
@@ -101,7 +101,7 @@ export default class AppIdList extends Vue {
    */
   private onClickRemoveHandler(data: IAppId) {
     this.appIdList = this.appIdList.filter((e) => e.appId !== data.appId)
-    dataModule.setAppIdList(this.appIdList)
+    appIdDataModule.setAppIdList(this.appIdList)
   }
 }
 </script>

--- a/components/common/data/appId/editAppIdList/EditAppIdList.vue
+++ b/components/common/data/appId/editAppIdList/EditAppIdList.vue
@@ -44,8 +44,8 @@ import Vue from 'vue'
 import Component from 'nuxt-class-component'
 
 import ModalTemplate from '@/components/common/template/ModalTemplate.vue'
-import ExportAppIdList from '@/components/common/data/ExportAppIdList.vue'
-import ImportAppIdList from '@/components/common/data/ImportAppIdList.vue'
+import ExportAppIdList from '@/components/common/data/appId/ExportAppIdList.vue'
+import ImportAppIdList from '@/components/common/data/appId/ImportAppIdList.vue'
 import AppIdList from './AppIdList.vue'
 import AddAppIdList from './AddAppIdList.vue'
 

--- a/components/common/data/modId/InitialRegisteredModId.vue
+++ b/components/common/data/modId/InitialRegisteredModId.vue
@@ -1,0 +1,91 @@
+<template>
+  <v-form v-model="formValid">
+    <v-container>
+      <v-row>
+        <v-col cols="12" md="12">
+          <v-text-field
+            v-model="modUrl"
+            :rules="modUrlRules"
+            label="MOD URL"
+            clearable
+            hint="お気に入りSteam MODのURLを入力してください"
+            persistent-hint
+            required
+          />
+          <v-text-field
+            v-model="gameName"
+            label="ゲーム名"
+            clearable
+            hint="MODのゲーム名を入力してください"
+            persistent-hint
+            required
+          />
+        </v-col>
+        <v-col cols="12" md="12">
+          <v-btn color="primary" block @click="onclickHandler"> 登録 </v-btn>
+        </v-col>
+        <v-col cols="12" md="12">
+          <!-- TODO: MOD IDインポート欄 -->
+          <!-- <import-app-id-list /> -->
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-form>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'nuxt-class-component'
+
+import { modIdDataModule } from '@/store/modules/dataModule/modIdDataModule'
+
+// import ImportAppIdList from '@/components/common/data/modId/ImportAppIdList.vue'
+
+import { IModId } from '~/store/modules/dataModule/types'
+
+import RegexpUtil from '~/utils/regexpUtil'
+
+/**
+ * MOD ID初期登録。
+ */
+@Component({
+  components: {
+    // ImportAppIdList,
+  },
+})
+export default class InitialRegisteredModId extends Vue {
+  /**
+   * フォームバリデーション状態。
+   */
+  private formValid = false
+  /**
+   * 入力されるMOD URL。
+   */
+  private modUrl = ''
+  /**
+   * 入力されるゲーム名。
+   */
+  private gameName = ''
+  /**
+   * 入力AppURLのバリデーションルール。
+   */
+  private modUrlRules = [
+    (v: string | undefined | null) =>
+      !!v || 'お気に入りSteam MODのURLを入力してください',
+    (v: string) =>
+      RegexpUtil.steamUrlToModId.test(v) || 'Steam MODのURLを入力してください',
+  ]
+
+  /**
+   * 登録ボタン押下時のハンドラー。
+   */
+  private onclickHandler() {
+    // MOD IDリストにデータを登録
+    const data: IModId = {
+      modId: RegexpUtil.match(this.modUrl, RegexpUtil.steamUrlToModId),
+      gameName: this.gameName,
+    }
+    modIdDataModule.setModId(data)
+  }
+}
+</script>

--- a/components/news/newsSummary/index.vue
+++ b/components/news/newsSummary/index.vue
@@ -37,7 +37,7 @@ import ApiWrapper from '@/components/common/api/ApiWrapper.vue'
 import NewsCard from '@/components/news/newsCard/index.vue'
 
 import { appWatcherModule } from '@/store/modules/appWatcherModule'
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 /**
  * ニュース一覧。
@@ -61,7 +61,7 @@ export default class NewsSummary extends Vue {
 
   async fetch() {
     const response = await appWatcherModule.getNewsForApp(
-      dataModule.currentAppId.appId
+      appIdDataModule.currentAppId.appId
     )
 
     this.data = response.appnews.newsitems

--- a/components/review/reviewSummary/index.vue
+++ b/components/review/reviewSummary/index.vue
@@ -48,7 +48,7 @@ import ReviewHistogram from '@/components/review/reviewHistogram/index.vue'
 import ReviewCard from '@/components/review/reviewCard/index.vue'
 
 import { appWatcherModule } from '@/store/modules/appWatcherModule'
-import { dataModule } from '@/store/modules/dataModule'
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
 
 import Settings from '~/config/settings'
 
@@ -76,10 +76,10 @@ export default class ReviewSummary extends Vue {
 
   async fetch() {
     this.reviewHistogramData = await appWatcherModule.getReviewHistogram(
-      dataModule.currentAppId.appId
+      appIdDataModule.currentAppId.appId
     )
     this.reviewData = await appWatcherModule.getReviewForAppWatcher(
-      dataModule.currentAppId.appId
+      appIdDataModule.currentAppId.appId
     )
   }
 

--- a/config/pageSettings/index.ts
+++ b/config/pageSettings/index.ts
@@ -1,19 +1,59 @@
 import { PageSetting } from './types'
 
+const top: PageSetting = {
+  title: 'TOP',
+  subTitle: '',
+  link: '/',
+  icon: 'fas fa-home',
+  breadcrumbs: [
+    {
+      text: 'TOP',
+      disabled: true,
+      href: '/',
+    },
+  ],
+}
+
 const appWatcher: PageSetting = {
   title: 'APP Watcher',
   subTitle: 'お気に入りアプリの今を知る',
-  link: '/',
-  // breadcrumbs: [
-  //   {
-  //     text: 'APP Watcher',
-  //     disabled: true,
-  //     href: '/',
-  //   },
-  // ],
+  link: '/appWatcher',
   icon: 'far fa-eye',
+  breadcrumbs: [
+    {
+      text: 'TOP',
+      disabled: false,
+      href: '/',
+    },
+    {
+      text: 'APP Watcher',
+      disabled: true,
+      href: '/',
+    },
+  ],
+}
+
+const modWatcher: PageSetting = {
+  title: 'MOD Watcher',
+  subTitle: 'お気に入りMODの今を知る',
+  link: '/modWatcher',
+  icon: 'fas fa-cubes',
+  breadcrumbs: [
+    {
+      text: 'TOP',
+      disabled: false,
+      href: '/',
+    },
+    {
+      text: 'MOD Watcher',
+      disabled: true,
+      href: '/',
+    },
+  ],
 }
 
 export const pageSettings = {
+  top,
   appWatcher,
+  modWatcher,
 }

--- a/config/pageSettings/types.ts
+++ b/config/pageSettings/types.ts
@@ -15,13 +15,13 @@ export interface PageSetting {
    */
   link: string
   /**
-   * パンくずリスト情報。
-   */
-  // breadcrumbs: Array<Breadcrumbs>
-  /**
    * ナビゲーションverに表示されるアイコン。
    */
   icon: string
+  /**
+   * パンくずリスト情報。
+   */
+  breadcrumbs: Array<Breadcrumbs>
 }
 
 export interface Breadcrumbs {

--- a/data/localStorage/appIdData.ts
+++ b/data/localStorage/appIdData.ts
@@ -4,13 +4,13 @@ import BaseLocalStorage from './base'
 import { IAppId } from '~/store/modules/dataModule/types'
 
 /**
- * APP ID, MOD IDを管理するClass。
+ * APP IDを管理するClass。
  */
-export default class DataLocalStorage extends BaseLocalStorage {
+export default class AppIdDataLocalStorage extends BaseLocalStorage {
   /**
-   * データがNULLの時に返却されるデータ。
+   * APP IDデータがNULLの時に返却されるデータ。
    */
-  public isErrorLocalStorageData = [
+  public isErrorAppIdLocalStorageData: Array<IAppId> = [
     {
       appId: '',
       label: '',
@@ -28,6 +28,7 @@ export default class DataLocalStorage extends BaseLocalStorage {
    */
   public isRegisteredAppIdList(): boolean {
     const appIdList = this.getLocalStorage(this.appIdListKeyName)
+
     if (appIdList === null) {
       return false
     }
@@ -40,7 +41,7 @@ export default class DataLocalStorage extends BaseLocalStorage {
   public getAppIdList(): Array<IAppId> {
     // アプリIDリストが登録されていなければ空データを返却
     if (!this.isRegisteredAppIdList()) {
-      return this.isErrorLocalStorageData
+      return this.isErrorAppIdLocalStorageData
     }
 
     // LocalStorageからデータ取得
@@ -54,7 +55,7 @@ export default class DataLocalStorage extends BaseLocalStorage {
         // アプリIDでない書式であれば、エラーを吐き空文字を返す
         console.log(`SteamアプリIDではない文字列がLocalStorageにセットされています。
 一度「LocalStorageをクリア」してからご利用ください。`)
-        return this.isErrorLocalStorageData
+        return this.isErrorAppIdLocalStorageData
       }
     })
 

--- a/data/localStorage/modIdData.ts
+++ b/data/localStorage/modIdData.ts
@@ -1,0 +1,94 @@
+import RegexpUtil from '@/utils/regexpUtil'
+import BaseLocalStorage from './base'
+
+import { IModId } from '~/store/modules/dataModule/types'
+
+/**
+ * MOD IDを管理するClass。
+ */
+export default class ModIdDataLocalStorage extends BaseLocalStorage {
+  /**
+   * MOD IDデータがNULLの時に返却されるデータ。
+   */
+  public isErrorModIdLocalStorageData: Array<IModId> = [
+    {
+      modId: '',
+      gameName: '',
+    },
+  ]
+
+  /**
+   * 現在登録中のMOD IDリスト。
+   */
+  private modIdListKeyName = 'steamWatcher_modIdList'
+
+  /**
+   * MOD IDリストがLocalStorageに登録されているかチェック。
+   * 登録されている=true/登録されていない~false
+   */
+  public isRegisteredModIdList(): boolean {
+    const modIdList = this.getLocalStorage(this.modIdListKeyName)
+    if (modIdList === null) {
+      return false
+    }
+    return true
+  }
+
+  /**
+   * 現在登録中のMOD IDリストがあるかどうか&あればデータをを返却。
+   */
+  public getModIdList(): Array<IModId> {
+    // MOD IDリストが登録されていなければ空データを返却
+    if (!this.isRegisteredModIdList()) {
+      return this.isErrorModIdLocalStorageData
+    }
+
+    // LocalStorageからデータ取得
+    const modIdList: Array<IModId> = JSON.parse(
+      this.getLocalStorage(this.modIdListKeyName) as string
+    )
+
+    // MOD IDの書式であるかどうかチェック
+    modIdList.forEach((e: IModId) => {
+      if (!RegexpUtil.test(e.modId, RegexpUtil.steamModId)) {
+        // MOD IDでない書式であれば、エラーを吐き空文字を返す
+        console.log(`Steam MOD IDではない文字列がLocalStorageにセットされています。
+一度「LocalStorageをクリア」してからご利用ください。`)
+        return this.isErrorModIdLocalStorageData
+      }
+    })
+
+    return modIdList
+  }
+
+  /**
+   * 現在登録中のMOD IDをセットする。
+   * @param data アプリIDデータ。
+   */
+  public setModId(data: IModId): void {
+    // MOD IDリストがLocalStorage内部に存在しないorErrorデータであれば新規作成
+    if (!this.isRegisteredModIdList()) {
+      const modIdList: Array<IModId> = [data]
+      this.setLocalStorage(this.modIdListKeyName, JSON.stringify(modIdList))
+    } else {
+      // MOD IDリストがLocalStorage内部に存在すれば追加処理
+      const modIdList = this.getModIdList()
+      modIdList.push(data)
+      this.setLocalStorage(this.modIdListKeyName, JSON.stringify(modIdList))
+    }
+  }
+
+  /**
+   * MOD IDリストを丸ごとセット。
+   */
+  public setModIdList(modIdList: Array<IModId>): void {
+    this.setLocalStorage(this.modIdListKeyName, JSON.stringify(modIdList))
+  }
+
+  /**
+   * MOD IDリスト情報を全て削除する。
+   */
+  public clearModIdList(): void {
+    this.clearLocalStorage(this.modIdListKeyName)
+  }
+}

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script>
-// import ExportAppIdList from '@/components/common/data/ExportAppIdList.vue'
+// import ExportAppIdList from '@/components/common/data/appId/ExportAppIdList.vue'
 
 export default {
   layout: 'empty',

--- a/pages/appWatcher.vue
+++ b/pages/appWatcher.vue
@@ -1,0 +1,130 @@
+<template>
+  <page-template :page-setting="pageSetting">
+    <template #main>
+      <!-- 登録中のアプリIDが存在しない: アプリID入力欄を提供 -->
+      <div v-if="!isRegisteredAppIdList">
+        <initial-registered-app-id />
+      </div>
+
+      <!-- 登録中のアプリID情報 -->
+      <!-- アプリIDが変更されたら再ロードされるようにKeyを設定 -->
+      <v-container
+        v-if="isRegisteredAppIdList && isRegisteredCurrentAppId"
+        :key="currentAppId.appId"
+      >
+        <v-row>
+          <v-col cols="12" class="pt-0">
+            <!-- アプリID表示/選択中のアプリIDを変更 -->
+            <current-app-id-list class="mb-2" />
+            <!-- お気に入りアプリの変更入力欄 -->
+            <edit-app-id-list />
+          </v-col>
+          <!-- お気に入りアプリ情報 -->
+          <v-col cols="12" sm="8" class="pt-0">
+            <app-details :app-id="currentAppId.appId" />
+          </v-col>
+
+          <!-- 現在プレイしている人数 -->
+          <v-col cols="12" sm="4" class="pt-0">
+            <now-player-num />
+          </v-col>
+        </v-row>
+
+        <!-- 最新ニュースリリース5件 -->
+        <v-row>
+          <v-col cols="12" class="pt-0">
+            <news-summary />
+          </v-col>
+        </v-row>
+
+        <!-- レビューサマリ -->
+        <v-row>
+          <v-col cols="12" sm="12" class="pt-0">
+            <review-summary />
+          </v-col>
+        </v-row>
+
+        <!-- 実績取得比率 -->
+        <v-row>
+          <v-col cols="12" class="pt-0">
+            <achivement-summary />
+          </v-col>
+        </v-row>
+
+        <!-- 登録中のアプリID削除ボタン -->
+        <v-row>
+          <v-col cols="12" class="pt-0">
+            <clear-registered-app-id />
+          </v-col>
+        </v-row>
+
+        <!-- API情報更新ボタン -->
+        <reload-steam-api-data />
+      </v-container>
+    </template>
+  </page-template>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator'
+
+import { appIdDataModule } from '@/store/modules/dataModule/appIdDataModule'
+
+import ReviewSummary from '~/components/review/reviewSummary/index.vue'
+import PageTemplate from '~/components/common/template/PageTemplate.vue'
+import InitialRegisteredAppId from '~/components/common/data/appId/InitialRegisteredAppId.vue'
+import CurrentAppIdList from '~/components/common/data/appId/CurrentAppIdList.vue'
+import EditAppIdList from '~/components/common/data/appId/editAppIdList/EditAppIdList.vue'
+import AppDetails from '~/components/common/AppDetails.vue'
+import NowPlayerNum from '~/components/appWatcher/NowPlayerNum.vue'
+import NewsSummary from '~/components/news/newsSummary/index.vue'
+import AchivementSummary from '~/components/appWatcher/achivement/AchivementSummary.vue'
+import ClearRegisteredAppId from '~/components/appWatcher/ClearRegisteredAppId.vue'
+import ReloadSteamApiData from '~/components/common/ReloadSteamApiData.vue'
+
+// settings import
+import { pageSettings } from '~/config/pageSettings'
+
+@Component({
+  components: {
+    PageTemplate,
+    InitialRegisteredAppId,
+    CurrentAppIdList,
+    EditAppIdList,
+    AppDetails,
+    NowPlayerNum,
+    NewsSummary,
+    ReviewSummary,
+    AchivementSummary,
+    ClearRegisteredAppId,
+    ReloadSteamApiData,
+  },
+})
+export default class AppWatcher extends Vue {
+  /**
+   * 画面設定。
+   */
+  private pageSetting = pageSettings.appWatcher
+
+  /**
+   *  現在選択中のアプリID。
+   */
+  private get currentAppId() {
+    return appIdDataModule.currentAppId
+  }
+
+  /**
+   * アプリIDリストが登録されているかどうか。
+   */
+  private get isRegisteredAppIdList() {
+    return appIdDataModule.isRegisteredAppIdList
+  }
+
+  /**
+   * アプリIDが登録されているかどうか。
+   */
+  get isRegisteredCurrentAppId(): boolean {
+    return appIdDataModule.isRegisteredCurrentAppId
+  }
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,66 +1,7 @@
 <template>
   <page-template :page-setting="pageSetting">
     <template #main>
-      <!-- 登録中のアプリIDが存在しない: アプリID入力欄を提供 -->
-      <div v-if="!isRegisteredAppIdList">
-        <initial-registered-app-id />
-      </div>
-
-      <!-- 登録中のアプリID情報 -->
-      <!-- アプリIDが変更されたら再ロードされるようにKeyを設定 -->
-      <v-container
-        v-if="isRegisteredAppIdList && isRegisteredCurrentAppId"
-        :key="currentAppId.appId"
-      >
-        <v-row>
-          <v-col cols="12" class="pt-0">
-            <!-- アプリID表示/選択中のアプリIDを変更 -->
-            <current-app-id-list class="mb-2" />
-            <!-- お気に入りアプリの変更入力欄 -->
-            <edit-app-id-list />
-          </v-col>
-          <!-- お気に入りアプリ情報 -->
-          <v-col cols="12" sm="8" class="pt-0">
-            <app-details :app-id="currentAppId.appId" />
-          </v-col>
-
-          <!-- 現在プレイしている人数 -->
-          <v-col cols="12" sm="4" class="pt-0">
-            <now-player-num />
-          </v-col>
-        </v-row>
-
-        <!-- 最新ニュースリリース5件 -->
-        <v-row>
-          <v-col cols="12" class="pt-0">
-            <news-summary />
-          </v-col>
-        </v-row>
-
-        <!-- レビューサマリ -->
-        <v-row>
-          <v-col cols="12" sm="12" class="pt-0">
-            <review-summary />
-          </v-col>
-        </v-row>
-
-        <!-- 実績取得比率 -->
-        <v-row>
-          <v-col cols="12" class="pt-0">
-            <achivement-summary />
-          </v-col>
-        </v-row>
-
-        <!-- 登録中のアプリID削除ボタン -->
-        <v-row>
-          <v-col cols="12" class="pt-0">
-            <clear-registered-app-id />
-          </v-col>
-        </v-row>
-
-        <!-- API情報更新ボタン -->
-        <reload-steam-api-data />
-      </v-container>
+      <v-container> TOPページ </v-container>
     </template>
   </page-template>
 </template>
@@ -68,19 +9,7 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator'
 
-import { dataModule } from '@/store/modules/dataModule'
-
-import ReviewSummary from '~/components/review/reviewSummary/index.vue'
 import PageTemplate from '~/components/common/template/PageTemplate.vue'
-import InitialRegisteredAppId from '~/components/common/data/InitialRegisteredAppId.vue'
-import CurrentAppIdList from '~/components/common/data/CurrentAppIdList.vue'
-import EditAppIdList from '~/components/common/data/editAppIdList/EditAppIdList.vue'
-import AppDetails from '~/components/common/AppDetails.vue'
-import NowPlayerNum from '~/components/appWatcher/NowPlayerNum.vue'
-import NewsSummary from '~/components/news/newsSummary/index.vue'
-import AchivementSummary from '~/components/appWatcher/achivement/AchivementSummary.vue'
-import ClearRegisteredAppId from '~/components/appWatcher/ClearRegisteredAppId.vue'
-import ReloadSteamApiData from '~/components/common/ReloadSteamApiData.vue'
 
 // settings import
 import { pageSettings } from '~/config/pageSettings'
@@ -88,43 +17,12 @@ import { pageSettings } from '~/config/pageSettings'
 @Component({
   components: {
     PageTemplate,
-    InitialRegisteredAppId,
-    CurrentAppIdList,
-    EditAppIdList,
-    AppDetails,
-    NowPlayerNum,
-    NewsSummary,
-    ReviewSummary,
-    AchivementSummary,
-    ClearRegisteredAppId,
-    ReloadSteamApiData,
   },
 })
-export default class AppWatcher extends Vue {
+export default class Top extends Vue {
   /**
    * 画面設定。
    */
-  private pageSetting = pageSettings.appWatcher
-
-  /**
-   *  現在選択中のアプリID。
-   */
-  private get currentAppId() {
-    return dataModule.currentAppId
-  }
-
-  /**
-   * アプリIDリストが登録されているかどうか。
-   */
-  private get isRegisteredAppIdList() {
-    return dataModule.isRegisteredAppIdList
-  }
-
-  /**
-   * アプリIDが登録されているかどうか。
-   */
-  get isRegisteredCurrentAppId(): boolean {
-    return dataModule.isRegisteredCurrentAppId
-  }
+  private pageSetting = pageSettings.top
 }
 </script>

--- a/pages/modWatcher.vue
+++ b/pages/modWatcher.vue
@@ -1,0 +1,68 @@
+<template>
+  <page-template :page-setting="pageSetting">
+    <template #main>
+      <!-- 登録中のMOD IDが存在しない: MOD ID入力欄を提供 -->
+      <div v-if="!isRegisteredModIdList">
+        <initial-registered-mod-id />
+      </div>
+
+      <!-- 登録中のMOD一覧 -->
+      <v-container v-if="isRegisteredModIdList">
+        {{ modIdList }}
+        <v-row>
+          <!-- TODO: 登録中のMOD ID編集欄 -->
+          <v-col cols="12" class="pt-0"> </v-col>
+          <!-- TODO: 登録中のMODリストカード一覧 -->
+          <v-col cols="12" sm="8" class="pt-0"> </v-col>
+        </v-row>
+
+        <!-- TODO: 登録中のMOD ID削除ボタン -->
+        <v-row>
+          <v-col cols="12" class="pt-0"> </v-col>
+        </v-row>
+
+        <!-- TODO: API情報更新ボタン -->
+        <!-- <reload-steam-api-data /> -->
+      </v-container>
+    </template>
+  </page-template>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator'
+
+import { modIdDataModule } from '@/store/modules/dataModule/modIdDataModule'
+
+import PageTemplate from '~/components/common/template/PageTemplate.vue'
+import InitialRegisteredModId from '~/components/common/data/modId/InitialRegisteredModId.vue'
+
+// settings import
+import { pageSettings } from '~/config/pageSettings'
+
+@Component({
+  components: {
+    PageTemplate,
+    InitialRegisteredModId,
+  },
+})
+export default class ModWatcher extends Vue {
+  /**
+   * 画面設定。
+   */
+  private pageSetting = pageSettings.modWatcher
+
+  /**
+   * MOD IDリストが登録されているかどうか。
+   */
+  private get isRegisteredModIdList() {
+    return modIdDataModule.isRegisteredModIdList
+  }
+
+  /**
+   * MOD IDリスト。
+   */
+  private get modIdList() {
+    return modIdDataModule.modIdList
+  }
+}
+</script>

--- a/store/modules/dataModule/appIdDataModule.ts
+++ b/store/modules/dataModule/appIdDataModule.ts
@@ -2,11 +2,11 @@ import { VuexModule, Module, getModule, Mutation } from 'vuex-module-decorators'
 import store from '~/store/store'
 
 import { IAppId } from '~/store/modules/dataModule/types'
-import DataLocalStorage from '~/data/localStorage/data'
+import AppIdDataLocalStorage from '~/data/localStorage/appIdData'
 
-const dataLocalStorage = new DataLocalStorage()
+const appIdDataLocalStorage = new AppIdDataLocalStorage()
 
-export interface IDataState {
+export interface IAppIdDataState {
   appIdList: Array<IAppId>
   currentAppId: IAppId
 }
@@ -15,14 +15,13 @@ export interface IDataState {
   namespaced: true,
   store,
   stateFactory: true,
-  name: 'data',
+  name: 'appIdData',
 })
-class DataModule extends VuexModule implements IDataState {
+class AppIdDataModule extends VuexModule implements IAppIdDataState {
   /**
    * アプリIDリストのprivate変数。
    */
-  private _appIdList: Array<IAppId> = dataLocalStorage.getAppIdList()
-
+  private _appIdList: Array<IAppId> = appIdDataLocalStorage.getAppIdList()
   /**
    * 現在選択中のアプリIDのprivate変数。
    */
@@ -44,7 +43,7 @@ class DataModule extends VuexModule implements IDataState {
       return false
     } else if (
       JSON.stringify(this._appIdList) ===
-      JSON.stringify(dataLocalStorage.isErrorLocalStorageData)
+      JSON.stringify(appIdDataLocalStorage.isErrorAppIdLocalStorageData)
     ) {
       return false
     }
@@ -60,7 +59,7 @@ class DataModule extends VuexModule implements IDataState {
     // アプリIDリストが存在しなければ新規作成
     if (
       JSON.stringify(this._appIdList) ===
-      JSON.stringify(dataLocalStorage.isErrorLocalStorageData)
+      JSON.stringify(appIdDataLocalStorage.isErrorAppIdLocalStorageData)
     ) {
       this._appIdList = [data]
     } else {
@@ -69,7 +68,7 @@ class DataModule extends VuexModule implements IDataState {
     }
 
     // LocalStorage上のデータを更新
-    dataLocalStorage.setAppId(data)
+    appIdDataLocalStorage.setAppId(data)
   }
 
   /**
@@ -90,7 +89,7 @@ class DataModule extends VuexModule implements IDataState {
     // 格納し直した値をセット
     this._appIdList = appIdList
     // LocalStorage上のデータを更新
-    dataLocalStorage.setAppIdList(appIdList)
+    appIdDataLocalStorage.setAppIdList(appIdList)
   }
 
   /**
@@ -121,9 +120,9 @@ class DataModule extends VuexModule implements IDataState {
   @Mutation
   public clearAppIdList(): void {
     // LocalStorage上のデータを更新
-    dataLocalStorage.clearAppIdList()
-    this._appIdList = dataLocalStorage.getAppIdList()
+    appIdDataLocalStorage.clearAppIdList()
+    this._appIdList = appIdDataLocalStorage.getAppIdList()
   }
 }
 
-export const dataModule = getModule(DataModule)
+export const appIdDataModule = getModule(AppIdDataModule)

--- a/store/modules/dataModule/modIdDataModule.ts
+++ b/store/modules/dataModule/modIdDataModule.ts
@@ -1,0 +1,123 @@
+import { VuexModule, Module, getModule, Mutation } from 'vuex-module-decorators'
+import store from '~/store/store'
+
+import { IModId } from '~/store/modules/dataModule/types'
+import ModIdDataLocalStorage from '~/data/localStorage/modIdData'
+
+const modIdDataLocalStorage = new ModIdDataLocalStorage()
+
+export interface IModIdDataState {
+  modIdList: Array<IModId>
+}
+@Module({
+  dynamic: true,
+  namespaced: true,
+  store,
+  stateFactory: true,
+  name: 'modIdData',
+})
+class ModIdDataModule extends VuexModule implements IModIdDataState {
+  /**
+   * MOD IDリストのprivate変数。
+   */
+  private _modIdList: Array<IModId> = modIdDataLocalStorage.getModIdList()
+
+  /**
+   * 登録中のMOD IDリスト。
+   * 未登録の場合は「`dataLocalStorage.isNoLocalStorageData(['']`)」を返す。
+   */
+  get modIdList(): Array<IModId> {
+    return this._modIdList
+  }
+
+  /**
+   * MOD IDが登録されているかどうか。
+   */
+  get isRegisteredModIdList(): boolean {
+    if (this._modIdList.length <= 0) {
+      return false
+    } else if (
+      JSON.stringify(this._modIdList) ===
+      JSON.stringify(modIdDataLocalStorage.isErrorModIdLocalStorageData)
+    ) {
+      return false
+    }
+    return true
+  }
+
+  /**
+   * MOD IDリストを新規作成&セット。
+   * @param data MOD IDデータ。
+   */
+  @Mutation
+  public setModId(data: IModId): void {
+    // MOD IDリストが存在しなければ新規作成
+    if (
+      JSON.stringify(this._modIdList) ===
+      JSON.stringify(modIdDataLocalStorage.isErrorModIdLocalStorageData)
+    ) {
+      this._modIdList = [data]
+    } else {
+      // MOD IDリストが存在すれば追加処理
+      this._modIdList.push(data)
+    }
+
+    // LocalStorage上のデータを更新
+    modIdDataLocalStorage.setModId(data)
+  }
+
+  /**
+   * MOD IDリストを丸ごとセット。
+   */
+  @Mutation
+  public setModIdList(rawModIdList: Array<IModId>): void {
+    // 不正な値が混入することを防ぐため、一度値を取り出し格納し直す。
+    const modIdList: Array<IModId> = []
+    rawModIdList.forEach((e) => {
+      const tmp: IModId = {
+        modId: e.modId,
+        gameName: e.gameName,
+      }
+      modIdList.push(tmp)
+    })
+
+    // 格納し直した値をセット
+    this._modIdList = modIdList
+    // LocalStorage上のデータを更新
+    modIdDataLocalStorage.setModIdList(modIdList)
+  }
+
+  // /**
+  //  * 現在選択中のMOD ID。
+  //  */
+  // get currentModId(): IModId {
+  //   return this._currentModId
+  // }
+
+  // /**
+  //  * MOD IDが登録されているかどうか。
+  //  */
+  // get isRegisteredCurrentModId(): boolean {
+  //   return this._currentModId.modId !== ''
+  // }
+
+  // /**
+  //  * 現在選択中のMOD IDをセット。
+  //  */
+  // @Mutation
+  // public setCurrentModId(data: IModId): void {
+  //   this._currentModId = data
+  // }
+
+  /**
+   * MOD IDを消去。
+   */
+  @Mutation
+  public clearModIdList(): void {
+    // LocalStorage上のデータを更新
+    modIdDataLocalStorage.clearModIdList()
+    this._modIdList = modIdDataLocalStorage.getModIdList()
+  }
+}
+
+export const modIdDataModule = getModule(ModIdDataModule)

--- a/store/modules/dataModule/types.ts
+++ b/store/modules/dataModule/types.ts
@@ -8,3 +8,14 @@ export interface IAppId {
    */
   label: string
 }
+
+export interface IModId {
+  /**
+   * MOD ID。
+   */
+  modId: string
+  /**
+   * ゲーム名。
+   */
+  gameName: string
+}

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,12 +1,14 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import { IAppWatcherState } from '~/store/modules/appWatcherModule'
-import { IDataState } from '~/store/modules/dataModule'
+import { IAppIdDataState } from '~/store/modules/dataModule/appIdDataModule'
+import { IModIdDataState } from '~/store/modules/dataModule/modIdDataModule'
 
 Vue.use(Vuex)
 
 export interface State {
   appWatcher: IAppWatcherState
-  data: IDataState
+  appIdData: IAppIdDataState
+  modIdData: IModIdDataState
 }
 export default new Vuex.Store<State>({})

--- a/utils/regexpUtil.ts
+++ b/utils/regexpUtil.ts
@@ -25,11 +25,20 @@ export default class RegexpUtil {
    * SteamURLからAppIdを抽出する正規表現パターン。
    */
   public static steamUrlToAppId: RegExp = /https:\/\/store.steampowered.com\/app\/([0-9]+)\//
+  /**
+   * SteamURLからModIdを抽出する正規表現パターン。
+   * https://steamcommunity.com/sharedfiles/filedetails/?id=2224118463
+   */
+  public static steamUrlToModId: RegExp = /https:\/\/steamcommunity.com\/sharedfiles\/filedetails\/\?id=([0-9]+)/
 
   /**
    * SteamAppIdの正規表現パターン。
    */
   public static steamAppId: RegExp = /^[0-9]+$/
+  /**
+   * SteamModIdの正規表現パターン。
+   */
+  public static steamModId: RegExp = /^[0-9]+$/
 
   /**
    * SteamApiの正規表現パターン。


### PR DESCRIPTION
その他含めた主な修正:

- Herokuデプロイエラー解消
- Vuex>`dataModule`を`appIdModule`と`modIdModule`に分割
- LocalStorage>`data`を`appId`と`modId`に分割
- TOPページ復活
- MOD Watcher画面作成
  - 初期登録フォーム作成